### PR TITLE
Fix udev rule for Linux

### DIFF
--- a/Linux/install-udev-rules.sh
+++ b/Linux/install-udev-rules.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-sudo echo "SUBSYSTEM==\"usb\", SYSFS{idVendor}==\"04e8\", SYSFS{idProduct}==\"6601\", MODE=\"0666\"" > /etc/udev/rules.d/60-heimdall-galaxy-s.rules
+sudo echo "SUBSYSTEM==\"usb\", SYSFS{idVendor}==\"04e8\", SYSFS{idProduct}==\"681c\", MODE=\"0666\"" > /etc/udev/rules.d/60-heimdall-galaxy-s.rules
 sudo service udev reload
 exit 0
 


### PR DESCRIPTION
The default udev rule for Linux is wrong.  The idProduct is different when in adb mode!  See output below (from Ubuntu Maverick on i386).

**In "normal" mode**:
    $ lsusb | grep Samsung
    Bus 001 Device 012: ID 04e8:6881 Samsung Electronics Co., Lt

**In adb mode**:
    $ lsusb | grep Samsung
    Bus 001 Device 012: ID 04e8:681c Samsung Electronics Co., Lt

See alanorth/Heimdall@dc9884decd8a54f32c6da2d82de461f5a25cfa6f

Thanks!
