### PR TITLE
Made heimdall-frontend buildable on older libqt4 versions

### DIFF
--- a/heimdall-frontend/Source/Packaging.cpp
+++ b/heimdall-frontend/Source/Packaging.cpp
@@ -301,7 +301,7 @@ bool Packaging::WriteTarEntry(const QString& filePath, QTemporaryFile *tarFile, 
 
 	// Note: We don't support base-256 encoding. Support could be added later.
 	sprintf(tarHeader.fields.size, "%011llo", file.size());
-	sprintf(tarHeader.fields.modifiedTime, "%011llo", qtFileInfo.lastModified().toMSecsSinceEpoch() / 1000);
+	sprintf(tarHeader.fields.modifiedTime, "%011llo", qtFileInfo.lastModified().toTime_t());
 		
 	// Regular File
 	tarHeader.fields.typeFlag = '0';


### PR DESCRIPTION
to a call to 'toTime_t()' which yields same result (as long as date is
between 1970-01-01 and 2106-02-07. This was done to allow compiling
with earlier Qt4 versions (such as qt4dev lib present on Ubuntu 10.04)
