### PR TITLE
Fix corruption when flashing large images on Samsung Galaxy S2

### DIFF
--- a/heimdall/source/BridgeManager.cpp
+++ b/heimdall/source/BridgeManager.cpp
@@ -628,7 +628,7 @@ bool BridgeManager::BeginSession(void)
 			else
 				Interface::Print("Session begun.\n\n", deviceType);
 
-			if (deviceType == 30)
+			if (deviceType == 30 || deviceType == 180)
 			{
 				Interface::Print("In certain situations this device may take up to 2 minutes to respond.\nPlease be patient!\n\n", deviceType);
 				Sleep(2000); // Give the user time to read the message.


### PR DESCRIPTION
Treat the Galaxy S2 I9100 similar to the Sky Rocket, in order to prevent corruption when flashing large factoryfs images.
Without this fix, corruptions appear randomly to files in /system, depending on the specific image.
Tested on several Galaxy S2 phones by comparing MD5 signature of all the files in /system with expected values.
