### PR TITLE
heimdall-frontend: Make the OUTPUTDIR variable work properly

### DIFF
--- a/heimdall-frontend/heimdall-frontend.pro
+++ b/heimdall-frontend/heimdall-frontend.pro
@@ -5,6 +5,10 @@
 TEMPLATE = app
 TARGET = heimdall-frontend
 
+isEmpty(OUTPUTDIR) {
+	OUTPUTDIR = $$(OUTPUTDIR)
+}
+
 macx {
 	message("")
 
@@ -49,7 +53,7 @@ macx {
 	isEmpty(OUTPUTDIR) {
 		DESTDIR = /Applications
 	} else {
-		DESTDIR = $$(OUTPUTDIR)
+		DESTDIR = $$OUTPUTDIR
 	}
 
 } else {
@@ -57,7 +61,7 @@ macx {
 		DESTDIR = ../Win32
 
 		!isEmpty(OUTPUTDIR) {
-			target.path = $$(OUTPUTDIR)
+			target.path = $$OUTPUTDIR
 			INSTALLS += target
 		}
 	} else {
@@ -66,7 +70,7 @@ macx {
 		isEmpty(OUTPUTDIR) {
 			target.path = /usr/local/bin
 		} else {
-			target.path = $$(OUTPUTDIR)
+			target.path = $$OUTPUTDIR
 		}
 
 		INSTALLS += target


### PR DESCRIPTION
$$OUTPUTDIR and $$(OUTPUTDIR) are distict; the former is a config
variable and the latter an environment variable, but
heimdall-frontend.pro mixes them. To get useful output
the user would have to invoke qmake like this:

OUTPUTDIR=/usr/bin qmake OUTPUTDIR=/usr/bin

This changeset allows the user to specify OUTPUTDIR via the environment OR
on the command line.
