### PR TITLE
Update OSX/README.txt to use clang and list Homebrew as libusb option

### DIFF
--- a/OSX/README.txt
+++ b/OSX/README.txt
@@ -491,7 +491,7 @@ Appendix B - Installing Heimdall from Source:
 
        http://www.libusb.org/
 
-       NOTE: Alternatively you may install Macport's libusb-devel package.
+       NOTE: Alternatively you may install libusb using Macports or Homebrew.
 
     4. Enter the following commands to compile libpit.
 


### PR DESCRIPTION
Added export of CC/CXX as described in issue #99 and listed Homebrew as an option (see issue #112).
