### PR TITLE
Fix udev rules directory

### DIFF
--- a/heimdall/Makefile.am
+++ b/heimdall/Makefile.am
@@ -22,7 +22,7 @@ heimdall_LDADD = $(DEPS_LIBS) $(STATIC_LIBS)
 
 if LINUXTARGET
 
-udevrulesdir = ${libdir}/udev/rules.d
+udevrulesdir = /lib/udev/rules.d
 udevrules_DATA = 60-heimdall.rules
 
 install-data-hook:

--- a/heimdall/Makefile.in
+++ b/heimdall/Makefile.in
@@ -377,7 +377,7 @@ heimdall_SOURCES = source/Arguments.cpp \
 	source/VersionAction.cpp
 
 heimdall_LDADD = $(DEPS_LIBS) $(STATIC_LIBS)
-@LINUXTARGET_TRUE@udevrulesdir = ${libdir}/udev/rules.d
+@LINUXTARGET_TRUE@udevrulesdir = /lib/udev/rules.d
 @LINUXTARGET_TRUE@udevrules_DATA = 60-heimdall.rules
 dist_noinst_SCRIPTS = autogen.sh
 all: config.h


### PR DESCRIPTION
The udev rules always must be installed in /lib/udev/rules.d even when it is
a 64 bits OS
