### PR TITLE
Fix error condition check on finding correct usb interface.

### DIFF
--- a/heimdall/source/BridgeManager.cpp
+++ b/heimdall/source/BridgeManager.cpp
@@ -232,7 +232,7 @@ int BridgeManager::FindDeviceInterface(void)
 
 	libusb_free_config_descriptor(configDescriptor);
 
-	if (result != LIBUSB_SUCCESS)
+	if (interfaceIndex < 0)
 	{
 		Interface::PrintError("Failed to find correct interface configuration\n");
 		return (BridgeManager::kInitialiseFailed);


### PR DESCRIPTION
Seems like the error check is wrong when testing if the correct interface was found after looping.
