### PR TITLE
Enabled build on FreeBSD.

### DIFF
--- a/heimdall/configure.ac
+++ b/heimdall/configure.ac
@@ -37,6 +37,12 @@ case $target in
 	AC_PROG_CXX
 	linuxtarget=false
 	;;
+*-freebsd*)
+	AC_DEFINE(OS_FREEBSD, [], [FreeBSD backend])
+	AC_MSG_RESULT([FreeBSD])
+	AC_PROG_CXX
+	linuxtarget=false
+	;;
 *)
 	AC_MSG_ERROR([unsupported operating system])
 esac

--- a/heimdall/source/Heimdall.h
+++ b/heimdall/source/Heimdall.h
@@ -30,7 +30,7 @@
 
 #include "../config.h"
 
-#if defined(OS_DARWIN) || defined(OS_LINUX)
+#if defined(OS_DARWIN) || defined(OS_LINUX) || defined(OS_FREEBSD)
 #include <unistd.h>
 #define Sleep(t) usleep(1000*t)
 #else
@@ -45,6 +45,17 @@
 #define nullptr 0
 #endif
 
+#endif
+
+#if defined(OS_FREEBSD)
+/* LibUSB-X fix. */
+enum libusb_log_level {
+        LIBUSB_LOG_LEVEL_NONE = 0,
+        LIBUSB_LOG_LEVEL_ERROR,
+        LIBUSB_LOG_LEVEL_WARNING,
+        LIBUSB_LOG_LEVEL_INFO,
+        LIBUSB_LOG_LEVEL_DEBUG,
+};
 #endif
 
 #endif

--- a/libpit/configure.ac
+++ b/libpit/configure.ac
@@ -36,6 +36,11 @@ case $target in
 	AC_MSG_RESULT([Windows])
 	AC_PROG_CXX
 	;;
+*-freebsd*)
+	AC_DEFINE(OS_FREEBSD, [], [FreeBSD backend])
+	AC_MSG_RESULT([FreeBSD])
+	AC_PROG_CXX
+	;;
 *)
 	AC_MSG_ERROR([unsupported operating system])
 esac


### PR DESCRIPTION
configure.ac scripts were updated with OS_FREEBSD detection.
Header files fix. LibUSB-X defines fix to build on FreeBSD-LibUSB.
Heimdall-Frontend works, remember about qt4-{gui,qmake,uic,moc,rcc,..}.