### PR TITLE
Gs5 fixes for Pit + flash

### DIFF
--- a/heimdall/source/BridgeManager.cpp
+++ b/heimdall/source/BridgeManager.cpp
@@ -916,7 +916,7 @@ int BridgeManager::ReceivePitFile(unsigned char **pitBuffer) const
 	for (unsigned int i = 0; i < transferCount; i++)
 	{
 		DumpPartPitFilePacket *requestPacket = new DumpPartPitFilePacket(i);
-		success = SendPacket(requestPacket);
+		success = SendPacket(requestPacket, kDefaultTimeoutSend, kEmptyTransferNone);
 		delete requestPacket;
 
 		if (!success)
@@ -929,7 +929,7 @@ int BridgeManager::ReceivePitFile(unsigned char **pitBuffer) const
 		int receiveEmptyTransferFlags = (i == transferCount - 1) ? kEmptyTransferAfter : kEmptyTransferNone;
 		
 		ReceiveFilePartPacket *receiveFilePartPacket = new ReceiveFilePartPacket();
-		success = ReceivePacket(receiveFilePartPacket, receiveEmptyTransferFlags);
+		success = ReceivePacket(receiveFilePartPacket, kDefaultTimeoutReceive, receiveEmptyTransferFlags);
 		
 		if (!success)
 		{


### PR DESCRIPTION
There are problems on the GS5 when sending empty bulk transfers during Pit file packet requests.This put the entire session into a wonky state. Request none be sent for these packets.
