### PR TITLE
Fixed CMake command for Windows readme

### DIFF
--- a/Win32/README.txt
+++ b/Win32/README.txt
@@ -543,5 +543,5 @@ Appendix B - Installing Heimdall Suite from Source
 
         mkdir build
         cd build
-        cmake -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DQt5Widgets_DIR=/c/msys64/mingw64/qt5-static/lib/cmake/Qt5Widgets ..
+        cmake -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DQt5Widgets_DIR=/mingw64/qt5-static/lib/cmake/Qt5Widgets ..
         make


### PR DESCRIPTION
`/c/msys64/mingw64/qt5-static/lib/cmake/Qt5Widgets` does not exist, as the root of the MSYS filesystem is already at C:\msys64 (or wherever MSYS was installed). Instead, use `/mingw64/qt5-static/lib/cmake/Qt5Widgets`