### PR TITLE
Add an option to disable GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,11 @@ project(Heimdall)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+option(DISABLE_FRONTEND "Disable GUI frontend" OFF)
+
 add_subdirectory(libpit)
 add_subdirectory(heimdall)
-add_subdirectory(heimdall-frontend)
-
-add_dependencies(heimdall-frontend heimdall)
+if(NOT DISABLE_FRONTEND)
+    add_subdirectory(heimdall-frontend)
+    add_dependencies(heimdall-frontend heimdall)
+endif()


### PR DESCRIPTION
I don't use the frontend at all. Disabling it at compile time has some benefits:
1. Shorter build time
2. No need to install Qt5.

Tested with:
```cmake -DDISABLE_FRONTEND=ON .```