### PR TITLE
Fix USB handling and timeouts for newer devices

### DIFF
--- a/heimdall/source/BridgeManager.h
+++ b/heimdall/source/BridgeManager.h
@@ -80,8 +80,8 @@ namespace Heimdall
 
 			enum
 			{
-				kDefaultTimeoutSend = 3000,
-				kDefaultTimeoutReceive = 3000,
+				kDefaultTimeoutSend = 6000,
+				kDefaultTimeoutReceive = 6000,
 				kDefaultTimeoutEmptyTransfer = 100
 			};
 


### PR DESCRIPTION
This commit should fix #228 #230 #209 #276 #190 #307 #141 #225 #286 for most new devices (they were all related to the same problems). The issues found were:
- kEmptyTransferAfter should no longer be the default (apparently) in most cases. I've instances where this was being used by default to explicit kEmptyTransferNone, which fixed a lot of the warnings my S5 was getting. I assume this is the case for all newer devices, but it may need customization of some kind if there are further problems.
- libusb_reset_device() must now be called after releasing the interface, since this is no longer being done by the device itself upon ending the session. Again, I assume this is the case for newer devices, but doing it ourselves simply ensures the reset happens even if the device also does it. Not resetting the device can result in --no-reboot leaving the device non-responsive to further sessions until it's unplugged and reattached.
- The packet timeout was too short, which was causing occasional timeout reports. It was especially bad when the device was connected to a USB3.0 port, since the speed negotiations seemed to be pushing the response times just past the timeouts, making it impossible to connect to the device at all. Doubling the default send and receive timeout seems to have resolved all of these issues on my S5.
