### PR TITLE
- fixed compiler warning: dead initialization (the values are never read)

### DIFF
--- a/heimdall/source/PrintPitAction.cpp
+++ b/heimdall/source/PrintPitAction.cpp
@@ -139,7 +139,7 @@ int PrintPitAction::Execute(int argc, char **argv)
 
 		// Load the local pit file into memory.
 		unsigned char *pitFileBuffer = new unsigned char[localPitFileSize];
-		size_t dataRead = fread(pitFileBuffer, 1, localPitFileSize, localPitFile); // dataRead is discarded, it's here to remove warnings.
+		(void)fread(pitFileBuffer, 1, localPitFileSize, localPitFile);
 		FileClose(localPitFile);
 
 		PitData *pitData = new PitData();

--- a/heimdall/source/SendFilePartPacket.h
+++ b/heimdall/source/SendFilePartPacket.h
@@ -46,9 +46,7 @@ namespace Heimdall
 
 				// min(fileSize, size)
 				unsigned int bytesToRead = (fileSize < size) ? fileSize - position : size;
-				
-				// bytesRead is discarded (it's just there to stop GCC warnings)
-				unsigned int bytesRead = fread(data, 1, bytesToRead, file);
+				(void)fread(data, 1, bytesToRead, file);
 			}
 
 			SendFilePartPacket(unsigned char *buffer, unsigned int size) : OutboundPacket(size)


### PR DESCRIPTION
In order to not get compiler warnings about 'unused return values'
a void cast is used, which also makes it clear the the returned values
are ignored on purpose