### PR TITLE
T-Flash mode: switch from internal MMC to SD-card

### DIFF
--- a/heimdall/source/FlashAction.cpp
+++ b/heimdall/source/FlashAction.cpp
@@ -398,7 +398,7 @@ static bool setTFlashMode(BridgeManager *bridgeManager)
 	}
 
 	TFlashModeResponse *tFlashModeResponse = new TFlashModeResponse();
-	success = bridgeManager->ReceivePacket(tFlashModeResponse);
+	success = bridgeManager->ReceivePacket(tFlashModeResponse, 5000);
 	unsigned int result = tFlashModeResponse->GetResult();
 	delete tFlashModeResponse;
 

--- a/heimdall/source/TFlashModePacket.h
+++ b/heimdall/source/TFlashModePacket.h
@@ -1,0 +1,65 @@
+/* Copyright (c) 2010-2014 Benjamin Dobell, Glass Echidna
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.*/
+
+#ifndef TFLASHMODEPACKET_H
+#define TFLASHMODEPACKET_H
+
+// Heimdall
+#include "ControlPacket.h"
+
+namespace Heimdall
+{
+	class TFlashModePacket : public ControlPacket
+	{
+		public:
+
+			enum
+			{
+				kRequestTFlashMode		= 0x08
+			};
+
+		protected:
+
+			enum
+			{
+				kDataSize = ControlPacket::kDataSize + 4
+			};
+
+		private:
+
+			unsigned int subcmd = TFlashModePacket::kRequestTFlashMode;
+
+		public:
+
+			TFlashModePacket(void) : ControlPacket(ControlPacket::kControlTypeSession)
+			{
+
+			}
+
+			virtual void Pack(void)
+			{
+				ControlPacket::Pack();
+
+				PackInteger(ControlPacket::kDataSize, subcmd);
+			}
+	};
+}
+
+#endif

--- a/heimdall/source/TFlashModeResponse.h
+++ b/heimdall/source/TFlashModeResponse.h
@@ -1,0 +1,58 @@
+/* Copyright (c) 2010-2014 Benjamin Dobell, Glass Echidna
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.*/
+
+#ifndef TFLASHMODERESPONSE_H
+#define TFLASHMODERESPONSE_H
+
+// Heimdall
+#include "ResponsePacket.h"
+
+namespace Heimdall
+{
+	class TFlashModeResponse : public ResponsePacket
+	{
+		private:
+
+			unsigned int result;
+
+		public:
+
+			TFlashModeResponse() : ResponsePacket(ResponsePacket::kResponseTypeSessionSetup)
+			{
+			}
+
+			unsigned int GetResult(void) const
+			{
+				return (result);
+			}
+
+			bool Unpack(void)
+			{
+				if (!ResponsePacket::Unpack())
+					return (false);
+
+				result = UnpackInteger(ResponsePacket::kDataSize);
+
+				return (true);
+			}
+	};
+}
+
+#endif


### PR DESCRIPTION
T-flash mode allows to write to external MMC (SD-Card) instead of the internal device memory.
Tested on SM-G900A (Galaxy S5)