### PR TITLE
Use library found instead of hardcoding compiler flag.

### DIFF
--- a/heimdall/CMakeLists.txt
+++ b/heimdall/CMakeLists.txt
@@ -45,4 +45,4 @@ use_large_files(heimdall YES)
 add_executable(heimdall ${HEIMDALL_SOURCE_FILES})
 
 target_link_libraries(heimdall PRIVATE pit)
-target_link_libraries(heimdall PRIVATE usb-1.0)
+target_link_libraries(heimdall PRIVATE ${LIBUSB_LIBRARY})


### PR DESCRIPTION
Fixes build on OpenBSD.