### PR TITLE
Ubuntu tweak

### DIFF
--- a/Linux/README
+++ b/Linux/README
@@ -490,3 +490,7 @@ Appendix B - Installing Heimdall Suite from Source:
             cmake -DCMAKE_BUILD_TYPE=Release ..
             make
 
+    4. Debian/Ubuntu users may need to use the following command after compiling
+       to make the program available to the operating system:
+
+            sudo cp bin/* /usr/local/bin


### PR DESCRIPTION
Added additional step to Appendix B to help address the Debian specific issue of how to compile 1.4.2 (needed to fix #292 on Debian systems) using instructions documented in #421.  Both issues have been closed, but without the matching PR @Benjamin-Dobell requested.  Hopefully this clears things up for future users.