### PR TITLE
Add BUNDLE DESTINATION to CMakeLists.txt

### DIFF
--- a/heimdall-frontend/CMakeLists.txt
+++ b/heimdall-frontend/CMakeLists.txt
@@ -52,5 +52,6 @@ target_link_libraries(heimdall-frontend Qt5::Widgets)
 target_link_libraries(heimdall-frontend z)
 install (TARGETS heimdall-frontend
 		RUNTIME	DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+		BUNDLE	DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
 		LIBRARY	DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
Without it:
```
grace:build ngarvey$ cmake  -DCMAKE_BUILD_TYPE=Release -DQt5Widgets_DIR=/usr/local/opt/qt5/lib/cmake/Qt5Widgets ..
CMake Error at heimdall-frontend/CMakeLists.txt:53 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "heimdall-frontend".
```

Reason:
https://cmake.org/cmake/help/v3.0/policy/CMP0006.html