### PR TITLE
Fix Compile Issues on macOS High Sierra 10.13.4

### DIFF
--- a/cmake/Findlibusb.cmake
+++ b/cmake/Findlibusb.cmake
@@ -23,6 +23,7 @@ find_library(LIBUSB_LIBRARY
     PATHS
         /usr/local/lib
         /opt/local/lib
+        /usr/local/Cellar/libusb/1.0.21
         /usr/lib
 )
 

--- a/heimdall-frontend/CMakeLists.txt
+++ b/heimdall-frontend/CMakeLists.txt
@@ -52,5 +52,7 @@ target_link_libraries(heimdall-frontend Qt5::Widgets)
 target_link_libraries(heimdall-frontend z)
 install (TARGETS heimdall-frontend
 		RUNTIME	DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+		RESOURCE DESTINATION ${CMAKE_INSTALL_PREFIX}
+		BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX}
 		LIBRARY	DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/heimdall/CMakeLists.txt
+++ b/heimdall/CMakeLists.txt
@@ -7,6 +7,9 @@ if((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (NOT DEFINED libusb_USE_STATIC
 endif((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (NOT DEFINED libusb_USE_STATIC_LIBS))
 
 find_package(libusb REQUIRED)
+#find_library(CF CoreFoundation)
+#find_library(IOK IOKit)
+#target_link_libraries(heimdall ${CF} ${IOK})
 
 set(LIBPIT_INCLUDE_DIRS
     ../libpit/source)
@@ -15,6 +18,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 if(MINGW)
     set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
+else(NOT MINGW)
+	set(CMAKE_EXE_LINKER_FLAGS "-lobjc -framework IOKit -framework CoreFoundation")
 endif(MINGW)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/libpit/CMakeLists.txt
+++ b/libpit/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(libpit)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dnullptr=NULL")
 
 set(LIBPIT_SOURCE_FILES
     source/libpit.cpp)


### PR DESCRIPTION
These two commits will allow Heimdall to compile successfully on macOS 10.13.4. I have tested this. One of the commits is from @brainstorm. The other is my own.