### PR TITLE
InitialiseProtocol: reset device before handshake

### DIFF
--- a/heimdall/source/BridgeManager.cpp
+++ b/heimdall/source/BridgeManager.cpp
@@ -303,6 +303,11 @@ bool BridgeManager::InitialiseProtocol(void)
 	memcpy(dataBuffer, "ODIN", 4);
 	memset(dataBuffer + 4, 0, 1);
 
+	if (libusb_reset_device(deviceHandle))
+	{
+		Interface::PrintError("Failed to reset device!");
+	}
+
 	if (!SendBulkTransfer(dataBuffer, 4, 1000))
 	{
 		Interface::PrintError("Failed to send handshake!");


### PR DESCRIPTION
Heimdall fails to handshake with device on my Linux installation:
Initialising protocol...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer.
ERROR: Failed to send handshake!
ERROR: Failed to receive handshake response. Result: -7
ERROR: Protocol initialisation failed!

However, with the same USB cable, port and device, Heimdall
successfully handshake with the device on Windows via WinUSB.
This indicates handling of USB devices of host (AMD X570) on
Linux might lead to undesired results. Though, without further
testing, the interference from userspace (Ubuntu 20.04, KDE) can
not be ruled out.

Thus, this patch calls libusb_reset_device to ensure
the USB port is in a clean state before we send the data.

Fixes issues with newer devices and hosts.

Signed-off-by: Jesse Chan <jc@linux.com>