### PR TITLE
Add an option to skip libusb_interface_alt_setting in FlashAction

### DIFF
--- a/heimdall/source/BridgeManager.cpp
+++ b/heimdall/source/BridgeManager.cpp
@@ -260,15 +260,19 @@ bool BridgeManager::ClaimDeviceInterface(void)
 bool BridgeManager::SetupDeviceInterface(void)
 {
 	Interface::Print("Setting up interface...\n");
+	
+	if(dont_set_libusb_interface_alt_setting) {
+		Interface::Print("Skipping alt interface setting...\n");
+	} else {
+		int result = libusb_set_interface_alt_setting(deviceHandle, interfaceIndex, altSettingIndex);
 
-	int result = libusb_set_interface_alt_setting(deviceHandle, interfaceIndex, altSettingIndex);
-
-	if (result != LIBUSB_SUCCESS)
-	{
-		Interface::PrintError("Setting up interface failed!\n");
-		return (false);
+		if (result != LIBUSB_SUCCESS)
+		{
+			Interface::PrintError("Setting up interface failed!\n");
+			return (false);
+		}
 	}
-
+	
 	Interface::Print("\n");
 	return (true);
 }
@@ -341,10 +345,11 @@ bool BridgeManager::InitialiseProtocol(void)
 	return (false);
 }
 
-BridgeManager::BridgeManager(bool verbose)
+BridgeManager::BridgeManager(bool verbose, bool dont_set_libusb_interface_alt_setting)
 {
 	this->verbose = verbose;
-
+	this->dont_set_libusb_interface_alt_setting = dont_set_libusb_interface_alt_setting;
+	
 	libusbContext = nullptr;
 	deviceHandle = nullptr;
 	heimdallDevice = nullptr;

--- a/heimdall/source/BridgeManager.h
+++ b/heimdall/source/BridgeManager.h
@@ -109,6 +109,7 @@ namespace Heimdall
 			static const DeviceIdentifier supportedDevices[kSupportedDeviceCount];
 
 			bool verbose;
+			bool dont_set_libusb_interface_alt_setting;
 
 			libusb_context *libusbContext;
 			libusb_device_handle *deviceHandle;
@@ -145,7 +146,7 @@ namespace Heimdall
 
 		public:
 
-			BridgeManager(bool verbose);
+			BridgeManager(bool verbose, bool dont_set_libusb_interface_alt_setting = false);
 			~BridgeManager();
 
 			bool DetectDevice(void);

--- a/heimdall/source/FlashAction.cpp
+++ b/heimdall/source/FlashAction.cpp
@@ -42,11 +42,11 @@ const char *FlashAction::usage = "Action: flash\n\
 Arguments:\n\
     [--<partition name> <filename> ...]\n\
     [--<partition identifier> <filename> ...]\n\
-    [--pit <filename>] [--verbose] [--no-reboot] [--resume] [--stdout-errors]\n\
+    [--pit <filename>] [--verbose] [--dont_set_libusb_interface_alt_setting] [--no-reboot] [--resume] [--stdout-errors]\n\
     [--usb-log-level <none/error/warning/debug>]\n\
   or:\n\
     --repartition --pit <filename> [--<partition name> <filename> ...]\n\
-    [--<partition identifier> <filename> ...] [--verbose] [--no-reboot]\n\
+    [--<partition identifier> <filename> ...] [--verbose] [--dont_set_libusb_interface_alt_setting] [--no-reboot]\n\
     [--resume] [--stdout-errors] [--usb-log-level <none/error/warning/debug>]\n\
     [--tflash]\n\
 Description: Flashes one or more firmware files to your phone. Partition names\n\
@@ -428,6 +428,7 @@ int FlashAction::Execute(int argc, char **argv)
 	argumentTypes["no-reboot"] = kArgumentTypeFlag;
 	argumentTypes["resume"] = kArgumentTypeFlag;
 	argumentTypes["verbose"] = kArgumentTypeFlag;
+	argumentTypes["dont_set_libusb_interface_alt_setting"] = kArgumentTypeFlag;
 	argumentTypes["stdout-errors"] = kArgumentTypeFlag;
 	argumentTypes["usb-log-level"] = kArgumentTypeString;
 	argumentTypes["tflash"] = kArgumentTypeFlag;
@@ -458,6 +459,7 @@ int FlashAction::Execute(int argc, char **argv)
 	bool reboot = arguments.GetArgument("no-reboot") == nullptr;
 	bool resume = arguments.GetArgument("resume") != nullptr;
 	bool verbose = arguments.GetArgument("verbose") != nullptr;
+	bool dont_set_libusb_interface_alt_setting = arguments.GetArgument("dont_set_libusb_interface_alt_setting") != nullptr;
 	bool tflash = arguments.GetArgument("tflash") != nullptr;
 	
 	if (arguments.GetArgument("stdout-errors") != nullptr)
@@ -534,7 +536,7 @@ int FlashAction::Execute(int argc, char **argv)
 
 	// Perform flash
 
-	BridgeManager *bridgeManager = new BridgeManager(verbose);
+	BridgeManager *bridgeManager = new BridgeManager(verbose, dont_set_libusb_interface_alt_setting);
 	bridgeManager->SetUsbLogLevel(usbLogLevel);
 
 	if (bridgeManager->Initialise(resume) != BridgeManager::kInitialiseSucceeded || !bridgeManager->BeginSession())


### PR DESCRIPTION
This should make it possible to flash phones like the Samsung Galaxy Ace I (Gt-S5830I) that otherwise fail to set up an interface

This should fix #278 , I was able to push a custom recovery using this patch and running `heimdall flash --dont_set_libusb_interface_alt_setting --boot <image>`

