### PR TITLE
Add SET_CONFIGURATION mandatory request

### DIFF
--- a/heimdall/source/BridgeManager.cpp
+++ b/heimdall/source/BridgeManager.cpp
@@ -257,6 +257,26 @@ bool BridgeManager::ClaimDeviceInterface(void)
 	return (true);
 }
 
+bool BridgeManager::SetupDeviceConfiguration(void)
+{
+	Interface::Print("Setting up configuration...\n");
+
+	int result = libusb_set_configuration(deviceHandle, 1);
+    // libusb_clear_halt(deviceHandle, 0x81);
+    // libusb_clear_halt(deviceHandle, 1);
+    // libusb_clear_halt(deviceHandle, 0x82);
+
+
+	if (result != LIBUSB_SUCCESS)
+	{
+		Interface::PrintError("Setting up configuration failed!\n");
+		return (false);
+	}
+
+	Interface::Print("\n");
+	return (true);
+}
+
 bool BridgeManager::SetupDeviceInterface(void)
 {
 	Interface::Print("Setting up interface...\n");
@@ -483,17 +503,20 @@ int BridgeManager::Initialise(bool resume)
 			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_DEBUG);
 			break;
 	}
-	
+
 	result = FindDeviceInterface();
 
 	if (result != BridgeManager::kInitialiseSucceeded)
 		return (result);
 
+	if(!SetupDeviceConfiguration())
+		return (BridgeManager::kInitialiseFailed);
+
 	if (!ClaimDeviceInterface())
 		return (BridgeManager::kInitialiseFailed);
 
-	if (!SetupDeviceInterface())
-		return (BridgeManager::kInitialiseFailed);
+	// if (!SetupDeviceInterface())
+	// 	return (BridgeManager::kInitialiseFailed);
 
 	if (!resume)
 	{
@@ -709,7 +732,7 @@ bool BridgeManager::SendPacket(OutboundPacket *packet, int timeout, int emptyTra
 	}
 
 	if (!SendBulkTransfer(packet->GetData(), packet->GetSize(), timeout))
-		return (false);
+			return (false);
 
 	if (emptyTransferFlags & kEmptyTransferAfter)
 	{

--- a/heimdall/source/BridgeManager.h
+++ b/heimdall/source/BridgeManager.h
@@ -134,6 +134,7 @@ namespace Heimdall
 			UsbLogLevel usbLogLevel;
 
 			int FindDeviceInterface(void);
+			bool SetupDeviceConfiguration(void);
 			bool ClaimDeviceInterface(void);
 			bool SetupDeviceInterface(void);
 			void ReleaseDeviceInterface(void);


### PR DESCRIPTION
Related to issue https://github.com/Benjamin-Dobell/Heimdall/issues/542.

In short, when flashing a Qualcomm-based device like  Samsung Galaxy Z Flip3 (SM-F711U1), the host sends "ODIN" but the device does not reply with "LOKE".

Heimdall is not calling SET_CONFIGURATION which should be mandatory. However, this breaks flashing for Mediatek-based devices, a condition should be added before this is merged.